### PR TITLE
Fix Unregister Bug & Add Functionality to Check Registered Type Converters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+typeconverter.iml
+.idea/

--- a/src/main/java/com/toddfast/util/convert/TypeConverter.java
+++ b/src/main/java/com/toddfast/util/convert/TypeConverter.java
@@ -200,14 +200,6 @@ public class TypeConverter {
 	}
 
 	/**
-	 * Unregister a type conversion object under the specified key
-	 *
-	 */
-	public static void unregisterTypeConversion(Object key) {
-		typeConversions.remove(key);
-	}
-
-	/**
 	 * Register a type conversion object under the specified keys. This
 	 * method can be used by developers to register custom type conversion
 	 * objects.
@@ -223,6 +215,14 @@ public class TypeConverter {
 		for (int i=0; i<keys.length; i++) {
 			registerTypeConversion(keys[i],conversion);
 		}
+	}
+
+	/**
+	 * Unregister a type conversion object under the specified key
+	 *
+	 */
+	public static void unregisterTypeConversion(Object key) {
+		typeConversions.remove(key);
 	}
 
 	/**

--- a/src/main/java/com/toddfast/util/convert/TypeConverter.java
+++ b/src/main/java/com/toddfast/util/convert/TypeConverter.java
@@ -178,6 +178,17 @@ public class TypeConverter {
 	}
 
 	/**
+	 * Return an immutable copy of the currently registered type conversion
+	 * objects.  The keys for the values in this map may be arbitrary objects, but
+	 * the values are of type <code>Conversion</code>
+	 *
+	 * @return Copy of the registred type conversions
+	 */
+	public static Map<Object,Conversion<?>> getRegisteredTypeConversions() {
+		return Collections.unmodifiableMap(new LinkedHashMap<Object,Conversion<?>>(typeConversions));
+	}
+
+	/**
 	 * Register a type conversion object under the specified key. This
 	 * method can be used by developers to register custom type conversion 
 	 * objects.

--- a/src/main/java/com/toddfast/util/convert/TypeConverter.java
+++ b/src/main/java/com/toddfast/util/convert/TypeConverter.java
@@ -235,7 +235,7 @@ public class TypeConverter {
 		if (conversion!=null) {
 			Object[] keys=conversion.getTypeKeys();
 			synchronized (typeConversions) {
-				if (keys==null) {
+				if (keys!=null) {
 					for (int i=0; i<keys.length; i++) {
 						unregisterTypeConversion(keys[i]);
 					}


### PR DESCRIPTION
The most important part of this PR is the fix for `unregisterTypeConversion(Conversion<?>)` where either a NPE would be thrown if a `Conversion#getTypeKeys` returned null, or it simply would not unregister the conversion if the instance passed is not the same instance as what was originally registered.

Other changes were minor:
- Relocated `unregisterTypeConversion(Object)` to be next to its overload
- Added a method to get a **copy** of the currently registered type conversions as an immutable map (`UnmodifiableMap` wrapping a new `LinkedHashMap` to be precise)
- Updated .gitignore file to ignore files generated by IntelliJ for it's IDE users (such as myself) 

All unit tests pass.